### PR TITLE
Fix problem with copying formatted numbers to SIM

### DIFF
--- a/app/src/main/java/com/github/yeriomin/dumbphoneassistant/Contact.java
+++ b/app/src/main/java/com/github/yeriomin/dumbphoneassistant/Contact.java
@@ -21,6 +21,10 @@ public class Contact implements Comparable<Contact> {
         return number;
     }
 
+    public String getNumberWithoutSeparators() {
+        return PhoneNumberUtils.stripSeparators(number);
+    }
+
     public String getLabel() {
         return label;
     }

--- a/app/src/main/java/com/github/yeriomin/dumbphoneassistant/SimUtil.java
+++ b/app/src/main/java/com/github/yeriomin/dumbphoneassistant/SimUtil.java
@@ -194,7 +194,7 @@ public class SimUtil extends Util {
             String firstLetter = label.substring(0, 1);
             name = name + "," + firstLetter;
         }
-        String number = contact.getNumber().replace("-", "");
+        String number = contact.getNumberWithoutSeparators();
         return new Contact(null, name, number);
     }
 }


### PR DESCRIPTION
If phone numbers were formatted with spaces by the system, the copying to SIM card would fail.
This fix removes the separators when copying contact to SIM.
The issue #3 should be fixed by this.